### PR TITLE
Stop recording when closing record dialog

### DIFF
--- a/scripts/popup/controller/TestDetails.controller.js
+++ b/scripts/popup/controller/TestDetails.controller.js
@@ -189,10 +189,14 @@ sap.ui.define([
 
         /**
          *
+         * @param {sap.ui.base.Event} oControlEvent the event attached to the closing action
          */
-        onStopRecord: function () {
-            RecordController.getInstance().stopRecording();
-            this._oRecordDialog.close();
+        onStopRecord: function (oControlEvent) {
+            // only stop recording iff the user pressed the cancel button 'Stop recording'
+            if (oControlEvent.getParameter("cancelPressed")) {
+                RecordController.getInstance().stopRecording();
+                this._oRecordDialog.close(); // dialog may be already closed
+            }
         },
 
         /**
@@ -553,6 +557,7 @@ sap.ui.define([
                 controller: this
             }).then(function(oRecordDialog) {
                 this._oRecordDialog = oRecordDialog;
+                this._oRecordDialog.attachClose(this.onStopRecord, this);
             }.bind(this));
 
             this._oMessagePopover = new MessagePopover({


### PR DESCRIPTION
During recording, the view 'TestDetails' displays the record dialog,
which is a BusyDialog control and indicates on-going recording. When
clicking the inherit button "Cancel recording", the recording is to be
stopped and the page injection should not lock interaction with the page
anymore.

The release of the page locking has been broken by a regression
introduced by commit fe1163e90ca75c36586f6e1891ca84e5e97a53b2. This is
fixed by attaching the function 'onStopRecord' to the record dialog's
closing event again.

This fixes #43.