### PR TITLE
Minor fixes to controller and view 'Teststep'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For further details, please see PR [#36](https://github.com/msg-systems/ui5-test
 - The page under test is now locked when it is not to be accessed (0232cc6)
 - Further user feedback is shown when extension or page disconnects/reloads (e.g., 17f7922, ba7a716, 7b35702, 9bd5167, and 8b102cd)
 - Add changelog file [CHANGELOG.md](CHANGELOG.md) (see Issue [#33](https://github.com/msg-systems/ui5-testrecorder/issues/33))
-
+- Correct catching of `<a>`-clicks (see Issue [#44](https://github.com/msg-systems/ui5-testrecorder/issues/44) and PR [#52](https://github.com/msg-systems/ui5-testrecorder/pull/52))
 
 ### Changed/Improved
 - Page injection and connection handling now uses WebExtension functionality, which improves stability (see Issue [#10](https://github.com/msg-systems/ui5-testrecorder/issues/10))
@@ -22,6 +22,7 @@ For further details, please see PR [#36](https://github.com/msg-systems/ui5-test
 - Use a single button 'Replay next step' during manual replay
 - Disable test-step handling during replay (8283ae9)
 - Refactor README file [README.md](README.md) (see Issue [#34](https://github.com/msg-systems/ui5-testrecorder/issues/34))
+- Speed of identification of many similar controls has been improved significantly (see Issue [#45](https://github.com/msg-systems/ui5-testrecorder/issues/45), PR [#50](https://github.com/msg-systems/ui5-testrecorder/pull/50) and [#53](https://github.com/msg-systems/ui5-testrecorder/pull/53))
 
 ### Fixed
 - Fix potential page injection problem with item properties (072a04e)

--- a/scripts/popup/controller/TestStep.controller.js
+++ b/scripts/popup/controller/TestStep.controller.js
@@ -236,7 +236,8 @@ sap.ui.define([
             this.byId("btSaveHeader").setBusy(true);
             this.byId("btSaveFooter").setBusy(true);
 
-            this._save().then(function () {
+            this._save()
+            .then(function () {
 
                 this.byId("btSaveHeader").setBusy(false);
                 this.byId("btSaveFooter").setBusy(false);
@@ -246,6 +247,10 @@ sap.ui.define([
                     TestId: this._sTestId
                 }, true);
                 RecordController.getInstance().startRecording();
+            }.bind(this))
+            .catch(function () {
+                this.byId("btSaveHeader").setBusy(false);
+                this.byId("btSaveFooter").setBusy(false);
             }.bind(this));
         },
 
@@ -1238,6 +1243,8 @@ sap.ui.define([
                             onClose: function (oAction) {
                                 if (oAction === MessageBox.Action.OK) {
                                     resolve();
+                                } else {
+                                    reject();
                                 }
                             }
                         });
@@ -1451,7 +1458,10 @@ sap.ui.define([
                             resolve();
                         }
                     }.bind(this));
-                }.bind(this));
+                }.bind(this))
+                .catch(function () {
+                    reject();
+                });
             }.bind(this));
         },
 

--- a/scripts/popup/controller/TestStep.controller.js
+++ b/scripts/popup/controller/TestStep.controller.js
@@ -306,7 +306,10 @@ sap.ui.define([
          *
          */
         onUpdatePreview: function () {
-            this._updatePreview();
+            Promise.all([
+                this._updatePreview(),
+                this._validateSelectedItemNumber()
+            ]);
         },
 
         /**
@@ -326,7 +329,10 @@ sap.ui.define([
                 this._oModel.setProperty("/element/attributeFilter", aFilter);
 
                 //update preview
-                this._updatePreview();
+                Promise.all([
+                    this._updatePreview(),
+                    this._validateSelectedItemNumber()
+                ]);
             }.bind(this));
         },
 
@@ -509,6 +515,7 @@ sap.ui.define([
                 this._updateValueState(oItem);
                 this._updateSubActionTypes();
                 this._updatePreview();
+                this._validateSelectedItemNumber();
 
                 this._resumeBindings();
             }.bind(this));
@@ -937,6 +944,7 @@ sap.ui.define([
             }
 
             this._updatePreview();
+            this._validateSelectedItemNumber();
             this._check();
         },
 

--- a/scripts/popup/controller/TestStep.controller.js
+++ b/scripts/popup/controller/TestStep.controller.js
@@ -1743,10 +1743,6 @@ sap.ui.define([
                     press: function () {
                         var aItems = this._oTableContext.getSelectedItems();
                         if (aItems && aItems.length) {
-                            Promise.all([
-                                this._updatePreview(),
-                                this._validateSelectedItemNumber()
-                            ]);
                             for (var j = 0; j < aItems.length; j++) {
                                 var oBndgCtxObj = aItems[j].getBindingContext("viewModel").getObject();
                                 this._add("/element/attributeFilter", {
@@ -1755,6 +1751,10 @@ sap.ui.define([
                                     subCriteriaType: oBndgCtxObj.bdgPath
                                 });
                             }
+                            Promise.all([
+                                this._updatePreview(),
+                                this._validateSelectedItemNumber()
+                            ]);
                         }
                         this._oSelectDialog.close();
                     }.bind(this)

--- a/scripts/popup/controller/TestStep.controller.js
+++ b/scripts/popup/controller/TestStep.controller.js
@@ -1414,13 +1414,9 @@ sap.ui.define([
                     // unlock view
                     this.getView().setBusy(false);
 
-                    // update found elements a last time before resolving as the element-specific messages are
-                    // attached to the identified elements and are not updated otherwise
-                    this._getMatchingElementCount().then(function () {
-                        resolve({
-                            rating: iGrade,
-                            messages: aMessages
-                        });
+                    resolve({
+                        rating: iGrade,
+                        messages: aMessages
                     });
 
                 }.bind(this));

--- a/scripts/popup/css/additional.css
+++ b/scripts/popup/css/additional.css
@@ -27,10 +27,12 @@
     /* height: 30px; */
 }
 
-.sapUiLocalBusyIndicatorAnimation>div::before {
+.sapUiLocalBusyIndicatorAnimation > div::before,
+.sapContrastPlus .sapUiLocalBusyIndicatorAnimation > div::before {
     background: #a01441;
 }
 
-.sapUiLocalBusyIndicatorAnimation>div::after {
+.sapUiLocalBusyIndicatorAnimation > div::after,
+.sapContrastPlus .sapUiLocalBusyIndicatorAnimation > div::after {
     box-shadow: inset 0 0 2px 1px #797979;
 }

--- a/scripts/popup/view/TestStep.view.xml
+++ b/scripts/popup/view/TestStep.view.xml
@@ -11,7 +11,7 @@
                                 </items>
                             </MenuItem>
 
-                            <MenuItem text="Aggregations" items="{ path: 'viewModel>/element/item/aggregationArray', filters: [{ path: 'length', operator: 'NE', value1: 0 }] }">
+                            <MenuItem text="Aggregations" items="{ path: 'viewModel>/element/item/aggregation', filters: [{ path: 'length', operator: 'NE', value1: 0 }] }">
                                 <items>
                                     <MenuItem text="{viewModel>name}" items="{viewModel>rows}">
                                         <items>


### PR DESCRIPTION
In this PR, some smaller issues in the controller and view 'TestStep' are fixed:
- Fix on-the-fly update of assert execution and action checking (dac9b1b)
- Fix busy-indicator color on dark controls (c82be48)
- Fix busy indicator not being reset on save in controller 'TestStep' (aff905c)
- Remove unnecessary call to page injection from controller 'TestStep' (09b6da5)
- Fix aggregation display in 'Navigate from Item' (67cea300a98bac6f36f016610ca618026d14d0ee, #48)
- Update found items after updating attribute filters in 'TestStep' (9a944c195ef72a09e5526c09695eb7569b333150, #54)

Additionally, the changelog is updated with respect to the last few PRs (d00d535).

### Changelog
#### Added
- Correct catching of `<a>`-clicks (see Issue [#44](https://github.com/msg-systems/ui5-testrecorder/issues/44) and PR [#52](https://github.com/msg-systems/ui5-testrecorder/pull/52))

#### Changed/Improved
- Speed of identification of many similar controls has been improved significantly (see Issue [#45](https://github.com/msg-systems/ui5-testrecorder/issues/45), PRs [#50](https://github.com/msg-systems/ui5-testrecorder/pull/50) and [#53](https://github.com/msg-systems/ui5-testrecorder/pull/53))